### PR TITLE
Update application.yml in sample-hystrix-monitor

### DIFF
--- a/sample-hystrix-monitor/src/main/resources/application.yml
+++ b/sample-hystrix-monitor/src/main/resources/application.yml
@@ -9,4 +9,5 @@ turbine:
   appConfig: SAMPLE-HYSTRIX-AGGREGATE
 
 logging:
-  level: INFO
+  level:
+    root: INFO


### PR DESCRIPTION
Bug: Failed to bind properties under 'logging.level'. Fix: Logger name mentioned explicitly (for SpringBoot 2.x.).